### PR TITLE
Bump release to 0.24.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ project = "Spyctl"
 copyright = "2023, SPYDERBAT, Inc., All Rights Reserved"
 author = "Spyderbat"
 release = "0.24"
-version = "0.24.1"
+version = "0.24.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spyctl"
-version = "0.24.1"
+version = "0.24.2"
 description = "A command line tool for viewing and managing Spyderbat Resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ wheels = [
 
 [[package]]
 name = "spyctl"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Patch bump from 0.24.1 to 0.24.2.
- Includes the org uid resolution cache landed in #35, which avoids the slow `/api/v1/org/` call on every spyctl invocation.

Updates `pyproject.toml`, `docs/conf.py`, and `uv.lock`.

## Test plan
- [ ] Merge, then create a `v0.24.2` GitHub release targeting `main` to trigger the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)